### PR TITLE
Update examples to use ANDROID_SDK_ROOT env var

### DIFF
--- a/android/android-espresso-demo-project/codemagic.yaml
+++ b/android/android-espresso-demo-project/codemagic.yaml
@@ -50,7 +50,7 @@ workflows:
                 EOF
             - name: Set Android SDK location
               script: |
-                echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/local.properties"
+                echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/local.properties"
             - name: Set up keystore
               script: |
                     echo $CM_KEYSTORE | base64 --decode > /tmp/keystore.keystore

--- a/ionic/ionic-capacitor-demo-project/codemagic.yaml
+++ b/ionic/ionic-capacitor-demo-project/codemagic.yaml
@@ -119,7 +119,7 @@ workflows:
                 npm install
             - name: Set Android SDK location
               script: |
-                echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/android/local.properties"
+                echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/android/local.properties"
             - name: Set up keystore
               script: |
                 echo $CM_KEYSTORE | base64 --decode > /tmp/keystore.keystore

--- a/react-native/react-native-demo-project/codemagic.yaml
+++ b/react-native/react-native-demo-project/codemagic.yaml
@@ -30,7 +30,7 @@ workflows:
                 npm install
             - name: Set Android SDK location
               script: |
-                echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/android/local.properties"
+                echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/android/local.properties"
             - name: Set up keystore
               script: |
                     echo $CM_KEYSTORE | base64 --decode > /tmp/keystore.keystore

--- a/react-native/react-native-detox-demo-project/codemagic.yaml
+++ b/react-native/react-native-detox-demo-project/codemagic.yaml
@@ -120,7 +120,7 @@ workflows:
                 npm install -g detox-cli
             - name: Set Android SDK location
               script: |
-                echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/android/local.properties"
+                echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/android/local.properties"
             - name: Set up keystore
               script: |
                     echo $CM_KEYSTORE | base64 --decode > /tmp/keystore.keystore


### PR DESCRIPTION
Xcode update from [12.4](https://docs.codemagic.io/specs/versions2/) to [12.5](https://docs.codemagic.io/specs/versions3/) broke builds based on the examples because of the change of the Android SDK path. This PR prevents misleading users in the future.