### PR TITLE
Skip creation of key.properties

### DIFF
--- a/react-native/react-native-demo-project/codemagic.yaml
+++ b/react-native/react-native-demo-project/codemagic.yaml
@@ -34,12 +34,6 @@ workflows:
             - name: Set up keystore
               script: |
                     echo $CM_KEYSTORE | base64 --decode > /tmp/keystore.keystore
-                    cat >> "$FCI_BUILD_DIR/android/key.properties" <<EOF
-                    storePassword=$CM_KEYSTORE_PASSWORD
-                    keyPassword=$CM_KEY_ALIAS_PASSWORD
-                    keyAlias=$CM_KEY_ALIAS_USERNAME
-                    storeFile=/tmp/keystore.keystore
-                    EOF               
             - name: Build Android release
               script: |
                 # Set environment variable so it can be used to increment build number in android/app/build.gradle


### PR DESCRIPTION
Doesn't look like the key.properties file is ever used, as the keystore properties are set directly in https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/react-native/react-native-demo-project/android/app/build.gradle#L158.