### PR TITLE
Trim .NET MAUI workload installs in yaml

### DIFF
--- a/dotnet-maui/dotnet-maui-android-ios/codemagic.yaml
+++ b/dotnet-maui/dotnet-maui-android-ios/codemagic.yaml
@@ -22,7 +22,7 @@ workflows:
       - name: Install MAUI
         script: |
           $DOTNET_BIN nuget locals all --clear 
-          $DOTNET_BIN workload install ios maui --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json      
+          $DOTNET_BIN workload install maui-ios --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json      
       - name: Set Info.plist values
         script: | 
           PLIST=$CM_BUILD_DIR/src/WeatherTwentyOne/Platforms/iOS/Info.plist
@@ -79,7 +79,7 @@ workflows:
         script: |
           $DOTNET_BIN nuget locals all --clear 
           # $DOTNET_BIN workload install maui --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
-          $DOTNET_BIN workload install android maui wasm-tools --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json      
+          $DOTNET_BIN workload install maui-android wasm-tools --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json      
       - name: Build
         script: |
           LATEST_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME")


### PR DESCRIPTION
This will minimize the workloads that you need to install when building a .NET MAUI iOS or Android app.

When you: `dotnet install maui` this will bring in the following:

* maui
    + maui-mobile
        - maui-android
        - maui-ios
        - maui-tizen
    + maui-desktop
        - maui-maccatalyst
        - maui-windows


maui-android and maui-ios include ios and android workloads.

The documentation says to `dotnet workload install ios maui`... This is too much for just an iOS or just an Android build. Minimizing it down to just maui-android or just maui-ios speed up the install and shorten build times :)


I think also at this point probably the nuget stuff can be removed as well, but for this PR i will leave it.