### PR TITLE
Replace `list-certificates` and `create-certificates` with `certificates list` and `certificates create`

### DIFF
--- a/flutter/flutter-macos-demo-project/README.md
+++ b/flutter/flutter-macos-demo-project/README.md
@@ -127,7 +127,7 @@ To code sign the app, add the following commands in the scripts section of the c
       - name: Fetch Mac Installer Distribution certificates
         script: |  
             app-store-connect certificates list --type MAC_APP_DISTRIBUTION --save || \
-            app-store-connect certificate create --type MAC_APP_DISTRIBUTION --save
+            app-store-connect certificates create --type MAC_APP_DISTRIBUTION --save
       - name: Set up signing certificate
         script: keychain add-certificates
       - name: Set up code signing settings on Xcode project

--- a/flutter/flutter-macos-demo-project/README.md
+++ b/flutter/flutter-macos-demo-project/README.md
@@ -126,8 +126,8 @@ To code sign the app, add the following commands in the scripts section of the c
             --create
       - name: Fetch Mac Installer Distribution certificates
         script: |  
-            app-store-connect list-certificates --type MAC_APP_DISTRIBUTION --save || \
-            app-store-connect create-certificate --type MAC_APP_DISTRIBUTION --save
+            app-store-connect certificates list --type MAC_APP_DISTRIBUTION --save || \
+            app-store-connect certificate create --type MAC_APP_DISTRIBUTION --save
       - name: Set up signing certificate
         script: keychain add-certificates
       - name: Set up code signing settings on Xcode project

--- a/flutter/flutter-macos-demo-project/codemagic.yaml
+++ b/flutter/flutter-macos-demo-project/codemagic.yaml
@@ -25,7 +25,7 @@ workflows:
           # HINT: We can use MAC_APP_DISTRIBUTION if looking to package the artifact before submitting it to App Store. 
           # And please note that the certificate type must match the one we are using in the Package macOS application script down below.
           app-store-connect certificates list --type MAC_INSTALLER_DISTRIBUTION --save || \
-          app-store-connect certificate create --type MAC_INSTALLER_DISTRIBUTION --save          
+          app-store-connect certificates create --type MAC_INSTALLER_DISTRIBUTION --save          
       - name: Set up signing certificate
         script: |
           keychain add-certificates

--- a/flutter/flutter-macos-demo-project/codemagic.yaml
+++ b/flutter/flutter-macos-demo-project/codemagic.yaml
@@ -24,8 +24,8 @@ workflows:
         script: |
           # HINT: We can use MAC_APP_DISTRIBUTION if looking to package the artifact before submitting it to App Store. 
           # And please note that the certificate type must match the one we are using in the Package macOS application script down below.
-          app-store-connect list-certificates --type MAC_INSTALLER_DISTRIBUTION --save || \
-          app-store-connect create-certificate --type MAC_INSTALLER_DISTRIBUTION --save          
+          app-store-connect certificates list --type MAC_INSTALLER_DISTRIBUTION --save || \
+          app-store-connect certificate create --type MAC_INSTALLER_DISTRIBUTION --save          
       - name: Set up signing certificate
         script: |
           keychain add-certificates

--- a/unity/unity-demo-project/README.md
+++ b/unity/unity-demo-project/README.md
@@ -446,7 +446,7 @@ In this step, you can also define the build artifacts you are interested in. The
     - name: Fetch Mac Installer Distribution certificates
       script: | 
         app-store-connect certificates list --type MAC_INSTALLER_DISTRIBUTION --save || \
-        app-store-connect certificate create --type MAC_INSTALLER_DISTRIBUTION --save 
+        app-store-connect certificates create --type MAC_INSTALLER_DISTRIBUTION --save 
     - name: Add certs to keychain
       script: | 
         keychain add-certificates

--- a/unity/unity-demo-project/README.md
+++ b/unity/unity-demo-project/README.md
@@ -445,8 +445,8 @@ In this step, you can also define the build artifacts you are interested in. The
           --create
     - name: Fetch Mac Installer Distribution certificates
       script: | 
-        app-store-connect list-certificates --type MAC_INSTALLER_DISTRIBUTION --save || \
-        app-store-connect create-certificate --type MAC_INSTALLER_DISTRIBUTION --save 
+        app-store-connect certificates list --type MAC_INSTALLER_DISTRIBUTION --save || \
+        app-store-connect certificate create --type MAC_INSTALLER_DISTRIBUTION --save 
     - name: Add certs to keychain
       script: | 
         keychain add-certificates

--- a/unity/unity-demo-project/codemagic.yaml
+++ b/unity/unity-demo-project/codemagic.yaml
@@ -263,7 +263,7 @@ workflows:
       - name: Fetch Mac Installer Distribution certificates
         script: |
           app-store-connect certificates list --type MAC_APP_DISTRIBUTION --save || \
-          app-store-connect certificate create --type MAC_APP_DISTRIBUTION --save
+          app-store-connect certificates create --type MAC_APP_DISTRIBUTION --save
       - name: Add certs to keychain
         script: keychain add-certificates
       - name: Set up code signing settings on Xcode project

--- a/unity/unity-demo-project/codemagic.yaml
+++ b/unity/unity-demo-project/codemagic.yaml
@@ -262,8 +262,8 @@ workflows:
             --create
       - name: Fetch Mac Installer Distribution certificates
         script: |
-          app-store-connect list-certificates --type MAC_APP_DISTRIBUTION --save || \
-          app-store-connect create-certificate --type MAC_APP_DISTRIBUTION --save
+          app-store-connect certificates list --type MAC_APP_DISTRIBUTION --save || \
+          app-store-connect certificate create --type MAC_APP_DISTRIBUTION --save
       - name: Add certs to keychain
         script: keychain add-certificates
       - name: Set up code signing settings on Xcode project


### PR DESCRIPTION
`app-storec-connect list-certificates` and `app-store-connect create-certificates` are deprecated, see: 

https://github.com/codemagic-ci-cd/cli-tools/blob/0bed134d36130ae0408fe973bd5fcd982f98f251/CHANGELOG.md?plain=1#L90