### PR TITLE
Get latest version from TestFlight

### DIFF
--- a/flutter/flutter-android-and-ios-yaml-demo-project/codemagic.yaml
+++ b/flutter/flutter-android-and-ios-yaml-demo-project/codemagic.yaml
@@ -82,9 +82,10 @@ workflows:
         ignore_failure: true
       - name: Flutter build ipa and automatic versioning
         script: |
+          # See the following link about getting the latest App Store or TestFlight version - https://docs.codemagic.io/knowledge-codemagic/build-versioning/#app-store-or-testflight-latest-build-number
           flutter build ipa --release \
             --build-name=1.0.0 \
-            --build-number=$(($(app-store-connect get-latest-app-store-build-number "$APP_ID") + 1)) \
+            --build-number=$(($(app-store-connect get-latest-testflight-build-number "$APP_ID") + 1)) \
             --export-options-plist=/Users/builder/export_options.plist
     artifacts:
       - build/ios/ipa/*.ipa


### PR DESCRIPTION
Most new users will need the latest build number from TestFlight rather than App Store. Set this as default, and add link to docs where they can see how to get App Store version.