### PR TITLE
Get version from TestFlight

### DIFF
--- a/react-native/react-native-demo-project/codemagic.yaml
+++ b/react-native/react-native-demo-project/codemagic.yaml
@@ -82,8 +82,9 @@ workflows:
                 xcode-project use-profiles --warn-only
             - name: Increment build number
               script: |
+                # Information about getting the latest build version can be found here: https://docs.codemagic.io/knowledge-codemagic/build-versioning/#app-store-or-testflight-latest-build-number
                 cd $CM_BUILD_DIR/ios
-                LATEST_BUILD_NUMBER=$(app-store-connect get-latest-app-store-build-number "$APP_ID")
+                LATEST_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number "$APP_ID")
                 agvtool new-version -all $(($LATEST_BUILD_NUMBER + 1))
             - name: Build ipa for distribution
               script: |


### PR DESCRIPTION
Most customers consulting these samples will be setting up their workflows for the first time so it would be better to advise getting the version number from TestFlight instead of a published app version. Also added a link so customers can see the available options.