### PR TITLE
Remove script that sets encryption delcaration

### DIFF
--- a/react-native/react-native-demo-project/codemagic.yaml
+++ b/react-native/react-native-demo-project/codemagic.yaml
@@ -71,12 +71,6 @@ workflows:
             - name: Install CocoaPods dependencies
               script: |
                 cd ios && pod install
-            - name: Set Info.plist values
-              script: |
-                # This allows publishing without manually answering the question about encryption 
-                PLIST=$CM_BUILD_DIR/$XCODE_SCHEME/Info.plist
-                PLIST_BUDDY=/usr/libexec/PlistBuddy
-                $PLIST_BUDDY -c "Add :ITSAppUsesNonExemptEncryption bool false" $PLIST
             - name: Set up code signing settings on Xcode project
               script: |
                 xcode-project use-profiles --warn-only


### PR DESCRIPTION
Configuration to state that the app doesn't use encryption should be set in the info.plist file once and then so it doesn't need to be set as part of the workflow every time.