### PR TITLE
Edit Path to XCODE_WORKSPACE

### DIFF
--- a/ionic/ionic-capacitor-demo-project/codemagic.yaml
+++ b/ionic/ionic-capacitor-demo-project/codemagic.yaml
@@ -11,7 +11,7 @@ workflows:
         bundle_identifier: io.codemagic.ionicsample
       vars:
         # Ionic Xcode worskspace and scheme
-        XCODE_WORKSPACE: "ios/App/App.xcworkspace"
+        XCODE_WORKSPACE: "App.xcworkspace"
         XCODE_SCHEME: "App"
         APP_STORE_APP_ID: 1555555551 # <-- Put the app id number here. This is found in App Store Connect > App > General > App Information
       node: v16.11.1


### PR DESCRIPTION
The existing [ionic-capacitor-demo-project](https://github.com/codemagic-ci-cd/codemagic-sample-projects/tree/main/ionic/ionic-capacitor-demo-project) codemagic.yaml file has 
```
XCODE_WORKSPACE: "ios/App/App.xcworkspace"
...
- name: Build ipa for distribution
        script: |
          cd $CM_BUILD_DIR/ios/App
          xcode-project build-ipa \
            --workspace "$XCODE_WORKSPACE" \
            --scheme "$XCODE_SCHEME"
``` 
which throws an error
```
xcode-project build-ipa: error: argument --workspace: Path "ios/App/App.xcworkspace" does not exist 
``` 
during the _build ipa_ step since directory is being changed to `$CM_BUILD_DIR/ios/App` during this step before reference is made to the `XCODE_WORKSPACE`. 
The solution is either to change the `ios/App/App.xcworkspace` to `App.xcworkspace` or remove `cd $CM_BUILD_DIR/ios/App` from the _build ipa_ step. 
Following the convention in some other sample projects yaml file, this PR changes `ios/App/App.xcworkspace` to `App.xcworkspace`