### PR TITLE
Fix: Ensure Correct Versioning by Adding --platform=ios Flag in Flutter iOS Workflow

### DIFF
--- a/flutter/flutter-android-and-ios-yaml-demo-project/codemagic.yaml
+++ b/flutter/flutter-android-and-ios-yaml-demo-project/codemagic.yaml
@@ -85,7 +85,7 @@ workflows:
           # See the following link about getting the latest App Store or TestFlight version - https://docs.codemagic.io/knowledge-codemagic/build-versioning/#app-store-or-testflight-latest-build-number
           flutter build ipa --release \
             --build-name=1.0.0 \
-            --build-number=$(($(app-store-connect get-latest-testflight-build-number "$APP_ID") + 1)) \
+            --build-number=$(($(app-store-connect get-latest-testflight-build-number --platform=IOS "$APP_ID") + 1)) \
             --export-options-plist=/Users/builder/export_options.plist
     artifacts:
       - build/ios/ipa/*.ipa


### PR DESCRIPTION
## Summary
This PR updates the iOS workflow to explicitly include the `--platform=IOS` argument in the build command when using automatic versioning. 
This helps prevent versioning issues in hybrid projects targeting both **iOS and macOS**, especially when relying on Codemagic’s automatic versioning feature.

## Why This Change Is Necessary
In projects that support **multiple Apple platforms** (e.g., both iOS and macOS), Codemagic’s automatic versioning can sometimes pull the latest TestFlight build number from the wrong platform—typically macOS—causing incorrect version increments.
By **explicitly defining** `--platform=IOS`, we ensure the build process fetches the correct version code from the **iOS App Store Connect** channel, maintaining proper version continuity.
Reference: [get-latest-testflight-build-number.md](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/get-latest-testflight-build-number.md)

## What Was Changed
Updated the flutter iOS build command to include:
```
--platform=IOS
```

## Testing
- Successfully tested the updated workflow in a multiplatform project.
- Versioning now consistently pulls from the correct platform (iOS).

