### PR TITLE
Fix typo for Google build number

### DIFF
--- a/react-native/react-native-demo-project/codemagic.yaml
+++ b/react-native/react-native-demo-project/codemagic.yaml
@@ -24,7 +24,7 @@ workflows:
             - name: Build Android release
               script: |
                 LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME")
-                if [ -z LATEST_BUILD_NUMBER ]; then
+                if [ -z "$LATEST_GOOGLE_PLAY_BUILD_NUMBER" ]; then
                   # fallback in case no build number was found from google play. Alternatively, you can `exit 1` to fail the build
                   UPDATED_BUILD_NUMBER=$BUILD_NUMBER
                 else


### PR DESCRIPTION
The logic to check for latest build number from Google Play was using wrong variable.